### PR TITLE
Can use the name of a test to create a fixture, with `deriveFixture`

### DIFF
--- a/core/src/main/kotlin/com/oneeyedmen/minutest/internal/MiContext.kt
+++ b/core/src/main/kotlin/com/oneeyedmen/minutest/internal/MiContext.kt
@@ -2,6 +2,7 @@ package com.oneeyedmen.minutest.internal
 
 import com.oneeyedmen.minutest.Named
 import com.oneeyedmen.minutest.Test
+import com.oneeyedmen.minutest.TestDescriptor
 
 internal sealed class TestNode
 
@@ -9,7 +10,7 @@ internal data class MiContext<PF, F>(
     override val name: String,
     override val parent: ParentContext<PF>,
     val children: List<TestNode>,
-    private val fixtureFactory: PF.() -> F,
+    private val fixtureFactory: PF.(TestDescriptor) -> F,
     private val operations: Operations<F>
 ) : ParentContext<F>, TestNode() {
 
@@ -25,7 +26,7 @@ internal data class MiContext<PF, F>(
         val testInParent = object : Test<PF>, Named by test {
             override fun invoke(parentFixture: PF): PF {
                 val transformedTest = operations.applyTransformsTo(testWithPreparedFixture)
-                val initialFixture = fixtureFactory(parentFixture)
+                val initialFixture = fixtureFactory(parentFixture, this)
                 transformedTest(initialFixture)
                 return parentFixture
             }

--- a/core/src/main/kotlin/com/oneeyedmen/minutest/internal/creating.kt
+++ b/core/src/main/kotlin/com/oneeyedmen/minutest/internal/creating.kt
@@ -2,6 +2,7 @@ package com.oneeyedmen.minutest.internal
 
 import com.oneeyedmen.minutest.Context
 import com.oneeyedmen.minutest.Test
+import com.oneeyedmen.minutest.TestDescriptor
 import kotlin.reflect.KClass
 import kotlin.reflect.KClassifier
 import kotlin.reflect.KType
@@ -36,14 +37,14 @@ fun <F> topLevelContext(
 fun <F> topLevelContext(
     name: String,
     type: KType,
-    fixtureBuilder: (Unit.() -> F)?,
+    fixtureBuilder: (Unit.(TestDescriptor) -> F)?,
     builder: Context<Unit, F>.() -> Unit
 ): Context<Unit, F> =
     ContextBuilder(name, type, fixtureBuilder, true).apply(builder)
 
 
 @Suppress("UNCHECKED_CAST")
-private fun <F> fixtureFunFor(isUnit: Boolean): (Unit.() -> F)? = if (isUnit) {{ Unit as F }} else null
+private fun <F> fixtureFunFor(isUnit: Boolean): (Unit.(TestDescriptor) -> F)? = if (isUnit) {{ Unit as F }} else null
 
 fun KClass<*>.asKType(isNullable: Boolean) =  object : KType {
     override val arguments: List<KTypeProjection> = emptyList()

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/NamingTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/NamingTests.kt
@@ -34,4 +34,35 @@ object NamingTests {
             log
         )
     }
+    
+    @org.junit.jupiter.api.Test
+    fun `names are passed to deriveFixture block`() {
+        val log = mutableListOf<List<String>>()
+        
+        class Fixture(val name: List<String>)
+        
+        executeTest(junitTests<Fixture> {
+            deriveFixture { testDescriptor ->
+                Fixture(testDescriptor.fullName())
+            }
+            
+            context("outer") {
+                test("outer test") { log.add(name) }
+                
+                context("inner") {
+                    test("inner test 1") { log.add(name) }
+                    test("inner test 2") { log.add(name) }
+                }
+            }
+        })
+        
+        assertEquals(
+            listOf(
+                listOf(javaClass.canonicalName, "outer", "outer test"),
+                listOf(javaClass.canonicalName, "outer", "inner", "inner test 1"),
+                listOf(javaClass.canonicalName, "outer", "inner", "inner test 2")
+            ),
+            log
+        )
+    }
 }


### PR DESCRIPTION
allows a fixture to be derived from the parent fixture *and* the full name of the test,  Use cases include creating a temp directory named after the test, or using the test name to create unique data in a persistent store, without having to define a TestTransform to get hold of the name of the test.

Example usage in the NamingTests