### PR TITLE
Tests use classes instead of objects

### DIFF
--- a/core/src/test/kotlin/com/oneeyedmen/minutest/DynamicTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/DynamicTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.TestFactory
 
 
-object DynamicTests {
+class DynamicTests {
 
     data class Fixture(
         var fruit: String,

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/FixtureSupplyingTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/FixtureSupplyingTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.TestFactory
 
 
-object FixtureSupplyingTests {
+class FixtureSupplyingTests {
 
     @TestFactory fun `supply fixture at top`() = junitTests("banana") {
         context("parent had no fixture") {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/FixtureTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/FixtureTests.kt
@@ -11,7 +11,7 @@ import java.io.FileNotFoundException
 import kotlin.streams.asSequence
 
 
-object FixtureTests {
+class FixtureTests {
 
     data class Fixture(
         var fruit: String,

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/ImmutableTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/ImmutableTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.TestFactory
 
 
-object ImmutableTests {
+class ImmutableTests {
 
     @TestFactory fun `before and after`() = junitTests<List<String>> {
         fixture { emptyList() }

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/NamingTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/NamingTests.kt
@@ -5,7 +5,7 @@ import com.oneeyedmen.minutest.junit.junitTests
 import org.junit.jupiter.api.Assertions.assertEquals
 
 
-object NamingTests {
+class NamingTests {
     
     @org.junit.jupiter.api.Test
     fun `fully qualified name`() {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/NullableFixtureTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/NullableFixtureTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.TestFactory
 
 
-object NullableFixtureTests {
+class NullableFixtureTests {
 
     @TestFactory fun `nullable String`() = junitTests<String?>(null) {
         test("fixture is null") {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/TransformTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/TransformTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 
 
-object TransformTests {
+class TransformTests {
     @Test
     fun `transforms wrap around application of before and after blocks`() {
         val log = mutableListOf<String>()

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/ContractsExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/ContractsExampleTests.kt
@@ -33,7 +33,7 @@ private fun TestContext<MutableCollection<String>>.behavesAsMutableCollection(
 
 // Now tests can invoke the function to verify the contract in a context
 
-object ArrayListTests : JupiterTests {
+class ArrayListTests : JupiterTests {
 
     override val tests = context<MutableCollection<String>> {
         behavesAsMutableCollection("ArrayList") { ArrayList() }
@@ -43,7 +43,7 @@ object ArrayListTests : JupiterTests {
 // We can reuse the contract for different collections.
 
 // Here we use the convenience InlineJupiterTests to reduce boilerplate
-object LinkedListTests : InlineJupiterTests<MutableCollection<String>>({
+class LinkedListTests : InlineJupiterTests<MutableCollection<String>>({
 
     behavesAsMutableCollection("LinkedList") { LinkedList() }
 

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/DerivedContextExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/DerivedContextExampleTests.kt
@@ -5,7 +5,7 @@ import com.oneeyedmen.minutest.junit.context
 import org.junit.jupiter.api.Assertions.assertEquals
 
 
-object DerivedContextExampleTests : JupiterTests {
+class DerivedContextExampleTests : JupiterTests {
 
     data class Fixture(val fruit: String)
 

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/FirstMinutests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/FirstMinutests.kt
@@ -5,9 +5,8 @@ import com.oneeyedmen.minutest.junit.context
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 
-// Minutests are usually defined in a object.
-// Implement JupiterTests to have them run by JUnit 5
-object FirstMinutests : JupiterTests {
+// Implement JupiterTests to run Minutests with JUnit 5
+class FirstMinutests : JupiterTests {
 
     // tests are grouped in a context
     override val tests = context<Unit> {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/FixtureExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/FixtureExampleTests.kt
@@ -5,7 +5,7 @@ import com.oneeyedmen.minutest.junit.context
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.util.*
 
-object FixtureExampleTests : JupiterTests {
+class FixtureExampleTests : JupiterTests {
 
     // We have multiple state, so make a separate fixture class
     class Fixture {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/GeneratingExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/GeneratingExampleTests.kt
@@ -42,7 +42,7 @@ private fun TestContext<StringStack>.cantPop() = test("cant pop") {
 }
 
 // In order to give multiple sets of tests, in this example we are using JUnit @TestFactory functions
-object GeneratingExampleTests {
+class GeneratingExampleTests {
 
     // JUnit will run the tests from annotated functions
     @TestFactory fun `stack tests`() = junitTests<StringStack> {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/ImmutableExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/ImmutableExampleTests.kt
@@ -5,7 +5,7 @@ import com.oneeyedmen.minutest.junit.context
 import org.junit.jupiter.api.Assertions.assertEquals
 
 
-object ImmutableExampleTests : JupiterTests {
+class ImmutableExampleTests : JupiterTests {
 
     // If you like this FP stuff, you may want to test an immutable fixture.
     override val tests = context<List<String>> {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/JunitRulesExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/JunitRulesExampleTests.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.rules.TemporaryFolder
 
 
-object JunitRulesExampleTests : JupiterTests {
+class JunitRulesExampleTests : JupiterTests {
 
     class Fixture {
         // make rules part of the fixture, no need for an annotation

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/ParameterisedTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/ParameterisedTests.kt
@@ -5,7 +5,7 @@ import com.oneeyedmen.minutest.junit.context
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 
-object ParameterisedTests : JupiterTests {
+class ParameterisedTests : JupiterTests {
 
     override val tests = context<Unit> {
 

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/SimpleStackExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/SimpleStackExampleTests.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import java.util.*
 
-object SimpleStackExampleTests : JupiterTests {
+class SimpleStackExampleTests : JupiterTests {
 
     // The fixture type is the generic type of the test, here Stack<String>
     override val tests = context<Stack<String>> {

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/StackExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/StackExampleTests.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.assertThrows
 import java.util.*
 
-object StackExampleTests : JupiterTests {
+class StackExampleTests : JupiterTests {
 
     override val tests = context<Stack<String>> {
 

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/examples/TheoriesExampleTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/examples/TheoriesExampleTests.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 
 // A translation of FizzBuzz tested with JUnit theories -
 // http://www.oneeyedmen.com/tdd-v-testing-part2.html
-object TheoriesExampleTests : JupiterTests {
+class TheoriesExampleTests : JupiterTests {
 
     override val tests = context<Unit> {
         (1..31).forEach { i ->

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/junit/JunitRulesTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/junit/JunitRulesTests.kt
@@ -8,7 +8,7 @@ import org.junit.runner.Description
 
 private val log = mutableListOf<String>()
 
-object JunitRulesTests {
+class JunitRulesTests {
     class TestRule : TestWatcher() {
         var testDescription: String? = null
         
@@ -48,15 +48,19 @@ object JunitRulesTests {
             log.add(rule.testDescription.toString())
         }
     }
-
-    @JvmStatic @AfterAll fun checkTestIsRun() {
-        assertEquals(
-            listOf(
-                "test 1",
-                "outer.apply rule fixture class.test 1(com.oneeyedmen.minutest.junit.JunitRulesTests)",
-                "test 2",
-                "outer.apply rule test class.test 2(com.oneeyedmen.minutest.junit.JunitRulesTests)"),
-            log)
+    
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun checkTestIsRun() {
+            assertEquals(
+                listOf(
+                    "test 1",
+                    "outer.apply rule fixture class.test 1(com.oneeyedmen.minutest.junit.JunitRulesTests)",
+                    "test 2",
+                    "outer.apply rule test class.test 2(com.oneeyedmen.minutest.junit.JunitRulesTests)"),
+                log)
+        }
     }
 }
 

--- a/core/src/test/kotlin/com/oneeyedmen/minutest/junit/JupiterTestsTests.kt
+++ b/core/src/test/kotlin/com/oneeyedmen/minutest/junit/JupiterTestsTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import java.util.*
 
 
-object JupiterTestsWithPlainFixture : JupiterTests {
+class JupiterTestsWithPlainFixture : JupiterTests {
 
     override val tests = context<String> {
         fixture { "banana" }
@@ -16,7 +16,7 @@ object JupiterTestsWithPlainFixture : JupiterTests {
     }
 }
 
-object JupiterTestsWithGenericFixture : JupiterTests {
+class JupiterTestsWithGenericFixture : JupiterTests {
 
     override val tests = context<Stack<String>> {
         fixture { Stack() }
@@ -27,7 +27,7 @@ object JupiterTestsWithGenericFixture : JupiterTests {
     }
 }
 
-object JupiterTestsWithNullableFixture : JupiterTests {
+class JupiterTestsWithNullableFixture : JupiterTests {
 
     override val tests = context<String?> {
         fixture { "banana" }
@@ -39,7 +39,7 @@ object JupiterTestsWithNullableFixture : JupiterTests {
     }
 }
 
-object JupiterTestsWithSuppliedFixture : JupiterTests {
+class JupiterTestsWithSuppliedFixture : JupiterTests {
 
     override val tests = context("banana") {
 
@@ -49,7 +49,7 @@ object JupiterTestsWithSuppliedFixture : JupiterTests {
     }
 }
 
-object InlineJupiterTestsTests : InlineJupiterTests<String>({
+class InlineJupiterTestsTests : InlineJupiterTests<String>({
     fixture { "banana" }
 
     test("test") {


### PR DESCRIPTION
JUnit 5 uses reflectomagic to instantiate test classes, which means that
it instantiates multiple instances of an object's class, violating its
singleton-ness.  Therefore it's safer to define tests in classes.