### PR TITLE
An abstract sealed class hieararchy modelling runtime contexts and tests

### DIFF
--- a/core/src/main/kotlin/com/oneeyedmen/minutest/internal/builders.kt
+++ b/core/src/main/kotlin/com/oneeyedmen/minutest/internal/builders.kt
@@ -53,9 +53,9 @@ internal class ContextBuilder<PF, F>(
 
     override fun addTransform(transform: TestTransform<F>) = operations.addTransform(transform)
 
-    override fun toRuntimeNode(parent: ParentContext<PF>): RuntimeContext<PF, F> {
+    override fun toRuntimeNode(parent: ParentContext<PF>): RuntimeContextWithFixture<PF, F> {
         operations.tryToResolveFixtureFactory(thereAreTests(), name)
-        return RuntimeContext(name, parent, emptyList(), operations).let { context ->
+        return RuntimeContextWithFixture(name, parent, emptyList(), operations).let { context ->
             // nastiness to set up parent child in immutable nodes
             context.copy(children = this.children.map { child -> child.toRuntimeNode(context) })
         }
@@ -66,5 +66,5 @@ internal class ContextBuilder<PF, F>(
 }
 
 internal data class TestBuilder<F>(val name: String, val f: F.() -> F) : NodeBuilder<F> {
-    override fun toRuntimeNode(parent: ParentContext<F>) = RuntimeTest(name, parent, f)
+    override fun toRuntimeNode(parent: ParentContext<F>) = RuntimeTestWithFixture(name, parent, f)
 }

--- a/core/src/main/kotlin/com/oneeyedmen/minutest/internal/runtime.kt
+++ b/core/src/main/kotlin/com/oneeyedmen/minutest/internal/runtime.kt
@@ -5,15 +5,23 @@ import com.oneeyedmen.minutest.Named
 
 sealed class RuntimeNode : Named
 
+abstract class RuntimeContext : RuntimeNode() {
+    abstract val children: List<RuntimeNode>
+}
+
+abstract class RuntimeTest: RuntimeNode() {
+    abstract fun run()
+}
+
 /**
  * The runtime representation of a context.
  */
-data class RuntimeContext<PF, F> internal constructor(
+internal data class RuntimeContextWithFixture<PF, F> internal constructor(
     override val name: String,
     override val parent: ParentContext<PF>,
-    val children: List<RuntimeNode>,
+    override val children: List<RuntimeNode>,
     private val operations: Operations<PF, F>
-) : ParentContext<F>, RuntimeNode() {
+) : RuntimeContext(), ParentContext<F> {
 
     override fun runTest(test: Test<F>) {
         parent.runTest(operations.buildParentTest(test))
@@ -23,10 +31,10 @@ data class RuntimeContext<PF, F> internal constructor(
 /**
  * The runtime representation of a test.
  */
-class RuntimeTest<F> internal constructor(
+internal class RuntimeTestWithFixture<F> internal constructor(
     override val name: String,
     override val parent: ParentContext<F>,
     private val f: F.() -> F
-) : Test<F>, RuntimeNode(), (F)-> F by f {
-    fun run() = parent.runTest(this)
+) : RuntimeTest(), Test<F>, (F)-> F by f {
+    override fun run() = parent.runTest(this)
 }

--- a/core/src/main/kotlin/com/oneeyedmen/minutest/junit/MinutestTestEngine.kt
+++ b/core/src/main/kotlin/com/oneeyedmen/minutest/junit/MinutestTestEngine.kt
@@ -2,8 +2,10 @@ package com.oneeyedmen.minutest.junit
 
 import com.oneeyedmen.minutest.experimental.TopLevelContextBuilder
 import com.oneeyedmen.minutest.internal.RuntimeContext
-import com.oneeyedmen.minutest.internal.RuntimeTest
+import com.oneeyedmen.minutest.internal.RuntimeContextWithFixture
+import com.oneeyedmen.minutest.internal.RuntimeTestWithFixture
 import com.oneeyedmen.minutest.internal.RuntimeNode
+import com.oneeyedmen.minutest.internal.RuntimeTest
 import org.junit.platform.engine.EngineDiscoveryRequest
 import org.junit.platform.engine.EngineExecutionListener
 import org.junit.platform.engine.ExecutionRequest
@@ -70,7 +72,7 @@ class MinutestTestEngine : TestEngine {
     
     private fun executeMinutestNode(descriptor: TestDescriptor, node: RuntimeNode, listener: EngineExecutionListener) {
         when (node) {
-            is RuntimeContext<*, *> -> {
+            is RuntimeContextWithFixture<*, *> -> {
                 childDescriptors(node).forEach { child ->
                     descriptor.addChild(child)
                     listener.dynamicTestRegistered(child)
@@ -78,13 +80,13 @@ class MinutestTestEngine : TestEngine {
                     execute(child, listener)
                 }
             }
-            is RuntimeTest<*> -> {
+            is RuntimeTestWithFixture<*> -> {
                 node.run()
             }
         }
     }
     
-    private fun childDescriptors(context: RuntimeContext<*, *>) =
+    private fun childDescriptors(context: RuntimeContextWithFixture<*, *>) =
         context.children.map { MinutestNodeDescriptor(it) }
     
     private fun executeChildren(test: TestDescriptor, listener: EngineExecutionListener) {
@@ -187,13 +189,13 @@ class MinutestNodeDescriptor(
 ) : MinutestDescriptor() {
     
     override fun getType() = when (node) {
-        is RuntimeContext<*, *> -> CONTAINER
-        is RuntimeTest<*> -> TEST
+        is RuntimeContext -> CONTAINER
+        is RuntimeTest -> TEST
     }
     
     override val idType: String = when (node) {
-        is RuntimeContext<*, *> -> "minutest-context"
-        is RuntimeTest<*> -> "minutest-test"
+        is RuntimeContext -> "minutest-context"
+        is RuntimeTest -> "minutest-test"
     }
     
     override val id: String = node.name

--- a/core/src/main/kotlin/com/oneeyedmen/minutest/junit/junit.kt
+++ b/core/src/main/kotlin/com/oneeyedmen/minutest/junit/junit.kt
@@ -49,9 +49,9 @@ fun NodeBuilder<Unit>.toStreamOfDynamicNodes(): Stream<out DynamicNode> =
     Stream.of(this.toRootRuntimeNode().toDynamicNode())
 
 private fun RuntimeNode.toDynamicNode(): DynamicNode = when (this) {
-    is RuntimeTest<*> -> dynamicTest(name) { this.run() }
-    is RuntimeContext<*, *> -> this.toDynamicContainer()
+    is RuntimeTest -> dynamicTest(name) { this.run() }
+    is RuntimeContext -> this.toDynamicContainer()
 }
 
-private fun RuntimeContext<*, *>.toDynamicContainer(): DynamicContainer =
+private fun RuntimeContext.toDynamicContainer(): DynamicContainer =
     dynamicContainer(name, children.map(RuntimeNode::toDynamicNode))


### PR DESCRIPTION
Allows navigation of the context/test hierarchy to be public while the
implementation details of how fixtures are instantiated is internal
to the library.

No need for star projections when navigating the test hierarchy.

(as discussed on Slack)